### PR TITLE
Add events .jsonl file to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### events jsonl file ###
+src/main/resources/events.jsonl


### PR DESCRIPTION
This adds the events file to .gitignore as it has potentially sensitive information.